### PR TITLE
[New "nginx_ssl_manage_certs" variable]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ nginx_extra_locations: |
 #    # ... add as many directives as you want;
 #  }
 
-# If this is false then your ssl cert/key is not transferred and none of the
-# ssl values are output to your nginx config.
+# If this is false then none of the ssl values are output to your nginx config.
 nginx_ssl: false
+
+# Set this to false if you have a separate role that manages copying
+# SSL certificates/keys to the server, and don't want this role
+# to attempt copying your SSL keys over
+nginx_ssl_manage_certs: true
 
 # What port should nginx listen on for https requests?
 nginx_listen_ssl: 443

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ nginx_ssl_strict_transport_header_age: 15768000
 nginx_ssl_session_cache: shared:SSL:10m
 nginx_ssl_session_timeout: 10m
 
+nginx_ssl_manage_certs: true
 nginx_ssl_local_path: /home/yourname/dev/testproject/secrets
 nginx_ssl_cert_name: sslcert.crt
 nginx_ssl_key_name: sslkey.key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   with_items:
     - "{{ nginx_ssl_cert_name }}"
     - "{{ nginx_ssl_key_name }}"
-  when: nginx_ssl
+  when: nginx_ssl and nginx_ssl_manage_certs
   notify:
     - reload nginx
 


### PR DESCRIPTION
Added a new "nginx_ssl_manage_certs" variable that makes the
process of copying certificates to the remote machine optional,
while still allowing the user to enable SSL.

This means that users can run a 'vault' based SSL key copying
mechanism, while still using this role.
