### PR TITLE
Added nginx_configure_ppa parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - "sudo apt-get update -qq"
 
 install:
-  - "pip install ansible==1.6.2"
+  - "pip install ansible==1.8.3"
   - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ nginx_ssl_key_name: sslkey.key
 
 # The amount in seconds to cache apt-update.
 apt_cache_valid_time: 86400
+
+# Should we install the Custom PPA for nginx?
+# Disable this if you are not using Ubuntu. If you set nginx_configure_ppa to false,
+# you will probably need to set 'nginx_spdy_enabled: false' too, since only the PPA version
+# includes spdy. nginx_names_hash_bucket_size will also need to be set to 64 in most cases
+nginx_configure_ppa: true
+
+# Should the SPDY extension be enabled?
+nginx_spdy_enabled: true
+
+# Configure server_names_hash_bucket_size
+nginx_names_hash_bucket_size: 32
+
 ```
 
 ## Example playbook without ssl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 nginx_listen: 80
 
+nginx_configure_ppa: true
+nginx_spdy_enabled: true
+nginx_names_hash_bucket_size: 32
+
 nginx_base_domain: "{{ ansible_fqdn }}"
 nginx_server_name: "{{ nginx_base_domain }}"
 nginx_base_redirect_to_www: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: ensure ansible's apt_repository dependency is installed
   apt: pkg=python-apt state=latest update_cache=true cache_valid_time={{ apt_cache_valid_time }}
+  when: nginx_configure_ppa
 
 - name: ensure nginx apt repository is up to date
   apt_repository: repo='ppa:nginx/stable'
+  when: nginx_configure_ppa
 
 - name: ensure nginx latest stable is installed
   apt: pkg=nginx state=latest update_cache=true cache_valid_time={{ apt_cache_valid_time }}

--- a/templates/nginx_conf.j2
+++ b/templates/nginx_conf.j2
@@ -15,6 +15,8 @@ http {
   # Basic Settings
   ##
 
+  server_names_hash_bucket_size {{ nginx_names_hash_bucket_size }};
+
   sendfile on;
   tcp_nopush on;
   tcp_nodelay on;

--- a/templates/nginx_sites-available.conf.j2
+++ b/templates/nginx_sites-available.conf.j2
@@ -31,7 +31,7 @@ server {
 server {
   listen {{ nginx_listen }};
 {% if nginx_ssl %}
-  listen {{ nginx_listen_ssl }} ssl spdy;
+  listen {{ nginx_listen_ssl }} ssl{{ ' spdy' if nginx_spdy_enabled else ''}};
 {% endif %}
   server_name {{ nginx_server_name }};
   root {{ nginx_root_path }};
@@ -63,7 +63,7 @@ server {
 {% if nginx_assets_enabled %}
   location {{ nginx_assets_regex }} {
     gzip_static on;
-    
+
     expires 1y;
     add_header Cache-Control public;
     add_header Last-Modified "";


### PR DESCRIPTION
- Allow the user to disable the custom PPA if they want. Keeps the default as enabled
- Allows the user to disable spdy - required for the base version of Nginx in Debian.
- Allows the user to configure server_names_hash_bucket_size using nginx_names_hash_bucket_size. Defaults to 32.