### PR TITLE
[www_redirect_use_base_domain] Redirect to www.{{nginx_base_domain}

### DIFF
--- a/templates/nginx_sites-available.conf.j2
+++ b/templates/nginx_sites-available.conf.j2
@@ -14,7 +14,7 @@ map $scheme $sts {
 server {
   listen {{ nginx_listen }};
   server_name {{ nginx_base_domain }};
-  return 301 $scheme://www.{{ nginx_server_name }}$request_uri;
+  return 301 $scheme://www.{{ nginx_base_domain }}$request_uri;
 }
 {% endif %}
 


### PR DESCRIPTION
If nginx_server_name is www.example.com, if someone goes to http://example.com/ they should be redirected to http://www.example.com/ - not http://www.www.example.com