### PR TITLE
Fixes unexpected 404 error

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -103,7 +103,7 @@ server {
 {% if item.custom_root_location_try_files %}
     try_files {{ item.custom_root_location_try_files }};
 {% else %}
-    try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else '' }} =404;
+    try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else '=404' }};
 {% endif %}
 {% if item.basic_auth | bool %}
     auth_basic "{{ item.basic_auth_message }}";


### PR DESCRIPTION
This modification fixes a bug I just encountered with a very basic configuration of this role.

Here are the properties of my system : 
- Role version : `v0.4.1`
- Nginx version : `nginx/1.12.0`
- Ubuntu 16.04

Here are my variables :
```
nginx_sites:
  api-staging:
    domains: "{{ domains }}"
    default_server: True
    upstreams:
      - name: 'api'
        servers: ['unix:///home/some/path.sock']
```
Which generates me, as expected :
```
  location / {
    try_files $uri $uri.html $uri/ @api =404;
  }

  location @api {
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_redirect off;
    proxy_pass http://api;
  }
```
However, calling a working endpoint gives me a 404 Error.

After a few tries, I found two ways of modifying this configuration to fix the error :
```
  location / {
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_redirect off;
    proxy_pass http://api;
  }
```
and
```
  location / {
    try_files $uri $uri.html $uri/ @api;
  }

  location @api {
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_redirect off;
    proxy_pass http://api;
  }
```

This pull request implements the second solution.

After some research, i found in [the documentation](https://nginx.org/en/docs/http/ngx_http_core_module.html#try_files) that "The last parameter can also point to a named location, as shown in examples below. Starting from version 0.7.51, the last parameter can also be a code". 

I'm no Nginx expert, but from what I understand, only the last parameter can be a named parameter, so this modification seems necessary.

I've tried to imagine what regressions this change could introduce, but so far can't see any : 
- Users using a `custom_root_location_try_files` are not affected
- Users with no upstream are not affected
- The last parameter of a try_files MUST be defined, but in our case, it is necessarily so, because of the structure of the template, so this shouldn't be an issue
- in case of unavailability of the upstream, we get a 502 error. I'm not sure how the current configuration is supposed to behave in such a case, but the 502 error sounds like what we want in such a situation.

Does this sound like a sensible change ?