### PR TITLE
Quick and dirty "fix" for sites that are all upstream

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ nginx_ssl_generate_self_signed_certs: True
 
 nginx_default_sites:
   default:
+    only_upstream: False
     domains: []
     default_server: False
     listen_http: 80

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -100,6 +100,21 @@ server {
   }
 
   location / {
+{% if item.only_upstream %}
+{% for upstream in item.upstreams %}
+    proxy_pass http://{{ upstream.name }};
+{% if nginx_default_upstream_proxy_settings is iterable -%}
+{% for key in nginx_default_upstream_proxy_settings %}
+    {{ key }};
+{% endfor %}
+{% endif %}
+{% if upstream.add_proxy_settings is defined -%}
+{% for setting in upstream.add_proxy_settings %}
+    {{ setting }};
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
 {% if item.custom_root_location_try_files %}
     try_files {{ item.custom_root_location_try_files }};
 {% else %}
@@ -108,6 +123,7 @@ server {
 {% if item.basic_auth | bool %}
     auth_basic "{{ item.basic_auth_message }}";
     auth_basic_user_file /etc/nginx/.htpasswd;
+{% endif %}
 {% endif %}
   }
 {% if item.upstreams %}


### PR DESCRIPTION
This fix works for me. I can define a site as "upstream_only", all requests are forwarded directly to the upstream-server. Not really merge:able, but maybe a quick way to demonstrate what would be needed