### PR TITLE
Use $host var in SSL redirect

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -25,7 +25,7 @@ server {
   }
 
   location / {
-    return 301 https://{{ item.domains[0] }}$request_uri;
+    return 301 https://$host$request_uri;
   }
 }
 


### PR DESCRIPTION
Instead of getting the redirect host from the ansible `domains` variable, get it from nginx's `$host` variable so that the user is redirected to the same host name they requested. This also allows using a wildcard (like ".domain.tld") as the first name in the `domains` variable without breaking the SSL redirect.