### PR TITLE
Add direct_proxy configuration variable to allow bypassing try_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ nginx_default_sites:
     # If you want to override the default / location's try_files, this is the
     # place to do it. This could be useful for php-fpm based virtual hosts.
     custom_root_location_try_files: ''
+    # Set direct_proxy to the name of an upstream to proxy ALL requests to it
+    # (bypasses try_file directive). Example:
+    # direct_proxy: apache
+    # upstreams:
+    #     - name: apache
+    #       servers: ['apache_upstream_server']
+    direct_proxy: ''
     # Is basic auth enabled for this virtual host?
     basic_auth: False
     # A 1 line message to show during the authentication required dialog.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,7 @@ nginx_default_sites:
       expires: 'max'
     custom_locations: ''
     custom_root_location_try_files: ''
+    direct_proxy: ''
     basic_auth: False
     basic_auth_message: 'Please sign in'
     disallow_hidden_files:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,16 @@
   notify:
     - Test nginx and reload
 
+- name: Expand common_proxy.conf
+  template:
+      src: 'etc/nginx/conf.d/common_proxy.conf.j2'
+      dest: '/etc/nginx/conf.d/common_proxy.conf'
+      group: 'root'
+      owner: 'root'
+      mode: '0644'
+  notify:
+      - Test nginx and reload
+
 - name: Configure nginx
   template:
     src: 'etc/nginx/nginx.conf.j2'

--- a/templates/etc/nginx/conf.d/common_proxy.conf.j2
+++ b/templates/etc/nginx/conf.d/common_proxy.conf.j2
@@ -1,0 +1,5 @@
+{% if nginx_default_upstream_proxy_settings is iterable -%}
+{% for key in nginx_default_upstream_proxy_settings %}
+  {{ key }};
+{% endfor %}
+{% endif %}

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -103,7 +103,7 @@ server {
 {% if item.custom_root_location_try_files %}
     try_files {{ item.custom_root_location_try_files }};
 {% else %}
-    try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else '' }} =404;
+    try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else ' =404' }};
 {% endif %}
 {% if item.basic_auth | bool %}
     auth_basic "{{ item.basic_auth_message }}";

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -100,19 +100,30 @@ server {
   }
 
   location / {
-{% if item.custom_root_location_try_files == '' $}
-    
-{% if item.custom_root_location_try_files %}
     include /etc/nginx/conf.d/common_proxy.conf;
+{% if item.direct_proxy and item.upstreams -%}
+  {% set upstream = item.upstreams|selectattr('name', '==', item.direct_proxy)|first -%}
+  {% if upstream -%}
+    {% if upstream.add_proxy_settings is defined -%}
+      {% for setting in upstream.add_proxy_settings %}
+        {{ setting }};
+
+      {% endfor %}
+    {% endif %}
+    proxy_pass http://{{ upstream.name }};
+  {% endif %}
+{% elif item.custom_root_location_try_files %}
     try_files {{ item.custom_root_location_try_files }};
 {% else %}
     try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else ' =404' }};
 {% endif %}
+
 {% if item.basic_auth | bool %}
     auth_basic "{{ item.basic_auth_message }}";
     auth_basic_user_file /etc/nginx/.htpasswd;
 {% endif %}
   }
+
 {% if item.upstreams %}
 {% for upstream in item.upstreams %}
 

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -100,7 +100,10 @@ server {
   }
 
   location / {
+{% if item.custom_root_location_try_files == '' $}
+    
 {% if item.custom_root_location_try_files %}
+    include /etc/nginx/conf.d/common_proxy.conf;
     try_files {{ item.custom_root_location_try_files }};
 {% else %}
     try_files $uri $uri.html $uri/{{ (' @' + item.upstreams[0].name) if (item.upstreams) else ' =404' }};
@@ -114,11 +117,7 @@ server {
 {% for upstream in item.upstreams %}
 
   location @{{ upstream.name }} {
-{% if nginx_default_upstream_proxy_settings is iterable -%}
-{% for key in nginx_default_upstream_proxy_settings %}
-    {{ key }};
-{% endfor %}
-{% endif %}
+    include /etc/nginx/conf.d/common_proxy.conf;
 {% if upstream.add_proxy_settings is defined -%}
 {% for setting in upstream.add_proxy_settings %}
     {{ setting }};


### PR DESCRIPTION
This pull request aims to fix Issue #13:

- the try_files directive falls back to the @upstream if it exists, otherwise to =404 (instead of both, which is invalid)
- a new `direct_proxy` variable is introduced. When it is set to the name of an upstream, it causes ALL requests to be proxied to that upstream (so there is no `try_files` directive). This is preferable to `try_files` when the upstream is meant to handle all requests (for example, when proxying to an Apache server that handles its own static files).

In the process I moved some proxy configuration to `/etc/nginx.conf.d/common_proxy.conf` to reduce clutter.

(Nick, I know you're currently working on a revamp of this role. I'm mostly posting this for anybody else who is using this role, and to give you ideas while you work on the new version.)