### PR TITLE
Allow user to provide main (top-level) directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ nginx_http_gzip: 'on'
 nginx_http_gzip_types: 'text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/svg'
 nginx_http_gzip_disable: 'msie6'
 
-# Add your own custom nginx.conf directives in a list.
+# Add your own custom nginx.conf main directives in a list.
+# Example:
+#   nginx_main_directives:
+#     - 'include /etc/nginx/modules-enabled/*.conf'
+nginx_main_directives: []
+
+# Add your own custom nginx.conf http directives in a list.
 # Example:
 #   nginx_http_directives:
 #     - 'auth_http_header X-Auth-Key "secret_string"'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ nginx_http_types_hash_max_size: 2048
 nginx_http_gzip: 'on'
 nginx_http_gzip_types: 'text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/svg'
 nginx_http_gzip_disable: 'msie6'
+nginx_main_directives: []
 nginx_http_directives: []
 
 nginx_basic_auth: []

--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -4,6 +4,14 @@ user {{ nginx_user }};
 worker_processes {{ nginx_worker_processes }};
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
+
+{% if nginx_main_directives is iterable -%}
+{% for key in nginx_main_directives %}
+  {{ key }};
+{% endfor %}
+{% endif %}
+
+
 events {
   worker_connections {{ nginx_events_worker_connections }};
 }


### PR DESCRIPTION
nginx_main_directives works the same as nginx_http_directives but is
outside of http block (useful for including dynamically-loaded modules).