### PR TITLE
Fix "no filter named 'changed'" and nginx restart

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,4 +112,4 @@
   service:
     name: 'nginx'
     state: 'restarted'
-  when: (nginx_register_nginx_config | changed) and (nginx_register_vhost_config | changed)
+  when: (nginx_register_nginx_config is changed) or (nginx_register_vhost_config is changed)


### PR DESCRIPTION
Replaced `| changed` with `is changed`. (Fixes #22)

Furthermore, if I am not mistaken nginx should be restarted if either config changes, not only if both change, correct?